### PR TITLE
fix: remove npm cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: '**/package-lock.json'
 
       - name: Install semantic-release dependencies
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Release workflow failure that occurred on the initial commit
- Removes npm cache configuration that was causing errors

## Problem
The workflow was trying to cache npm dependencies using `cache-dependency-path: '**/package-lock.json'`, but no package-lock.json file exists in the repository since we install semantic-release dependencies dynamically during the workflow run.

## Solution
Remove the npm cache configuration from the Setup Node.js step, allowing the workflow to proceed without caching.

## Test Plan
- [x] Workflow syntax is valid
- [ ] Workflow will run successfully after merge

Fixes: https://github.com/ejlevin1/caddy-failover/actions/runs/16982836521