### PR TITLE
docs: improve documentation for failover_status directive ordering

### DIFF
--- a/DIRECTIVE_ORDERING.md
+++ b/DIRECTIVE_ORDERING.md
@@ -1,0 +1,134 @@
+# Directive Ordering in Caddy Failover Plugin
+
+## The Issue
+
+When using the `failover_status` directive within a `handle` block, you may encounter this error:
+
+```
+Error: adapting config using caddyfile: parsing caddyfile tokens for 'handle':
+directive 'failover_status' is not an ordered HTTP handler
+```
+
+This occurs because Caddy needs to know the order in which to execute directives within a `handle` block.
+
+## Solutions
+
+### Solution 1: Global Order Directive (Recommended)
+
+Add the order directives to your global options block:
+
+```caddyfile
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /api/* {
+        failover_proxy http://backend1:8080 http://backend2:8080 {
+            fail_duration 10s
+        }
+    }
+}
+```
+
+### Solution 2: Use `route` Instead of `handle`
+
+The `route` directive doesn't require ordering:
+
+```caddyfile
+:8080 {
+    route /admin/failover/status {
+        failover_status
+    }
+
+    route /api/* {
+        failover_proxy http://backend1:8080 http://backend2:8080 {
+            fail_duration 10s
+        }
+    }
+}
+```
+
+## Why This Happens
+
+Caddy's `handle` directive requires all contained directives to have a defined order. This ensures predictable request processing. The `failover_proxy` and `failover_status` directives are custom handlers that need to be explicitly ordered.
+
+The `route` directive, on the other hand, executes directives in the order they appear in the Caddyfile, so no explicit ordering is needed.
+
+## Best Practices
+
+1. **Always include order directives** in your global options when using `failover_proxy` and `failover_status`
+2. **Use consistent ordering** across your configuration
+3. **Consider using `route`** for simpler configurations where execution order is clear
+
+## Full Example
+
+Here's a complete working example with proper ordering:
+
+```caddyfile
+{
+    # Required ordering for failover directives
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+
+    # Optional: enable debug logging
+    debug
+}
+
+# Main site
+:443 {
+    # Admin status endpoint
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    # API with failover
+    handle /api/* {
+        failover_proxy http://api1.local:8080 http://api2.local:8080 {
+            fail_duration 30s
+            dial_timeout 2s
+            response_timeout 5s
+
+            health_check http://api1.local:8080 {
+                path /health
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            health_check http://api2.local:8080 {
+                path /health
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+        }
+    }
+
+    # Default handler
+    handle {
+        respond "Welcome" 200
+    }
+}
+```
+
+## Testing Your Configuration
+
+Before deploying, always validate your Caddyfile:
+
+```bash
+caddy validate --config Caddyfile --adapter caddyfile
+```
+
+Or with Docker:
+
+```bash
+docker run --rm -v $(pwd)/Caddyfile:/etc/caddy/Caddyfile \
+    ghcr.io/ejlevin1/caddy-failover:latest \
+    caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+```

--- a/README.md
+++ b/README.md
@@ -297,6 +297,9 @@ docker run -d \
 
 Monitor the health and status of all failover proxies via REST API:
 
+**Important**: The `failover_status` directive requires proper ordering. Choose one of these approaches:
+
+**Option 1: Use global order directive (recommended)**
 ```caddyfile
 {
     order failover_proxy before reverse_proxy
@@ -318,6 +321,16 @@ Monitor the health and status of all failover proxies via REST API:
                 interval 30s
             }
         }
+    }
+}
+```
+
+**Option 2: Use route instead of handle (no order directive needed)**
+```caddyfile
+:443 {
+    # Status endpoint using route (doesn't require ordering)
+    route /admin/failover/status {
+        failover_status
     }
 }
 ```

--- a/test-directive-ordering.sh
+++ b/test-directive-ordering.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# Test script to verify directive ordering fix
+
+set -e
+
+echo "Testing failover_status directive ordering issue"
+echo "================================================"
+
+# Build the Docker image
+echo "Building Docker image..."
+docker build -t caddy-failover:ordering-test .
+
+# Test 1: Without order directive (should fail)
+echo ""
+echo "Test 1: Configuration WITHOUT order directive (expected to fail)..."
+cat > test-no-order.Caddyfile <<EOF
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+}
+EOF
+
+echo "Testing configuration validation..."
+if docker run --rm -v $(pwd)/test-no-order.Caddyfile:/etc/caddy/Caddyfile caddy-failover:ordering-test caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | grep -q "not an ordered HTTP handler"; then
+    echo "✅ Test 1 PASSED: Correctly failed without order directive"
+else
+    echo "❌ Test 1 FAILED: Should have failed without order directive"
+fi
+
+# Test 2: With order directive (should succeed)
+echo ""
+echo "Test 2: Configuration WITH order directive (expected to succeed)..."
+cat > test-with-order.Caddyfile <<EOF
+{
+    order failover_status before respond
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+}
+EOF
+
+echo "Testing configuration validation..."
+if docker run --rm -v $(pwd)/test-with-order.Caddyfile:/etc/caddy/Caddyfile caddy-failover:ordering-test caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | grep -q "Valid configuration"; then
+    echo "✅ Test 2 PASSED: Configuration is valid with order directive"
+else
+    echo "❌ Test 2 FAILED: Configuration should be valid with order directive"
+    docker run --rm -v $(pwd)/test-with-order.Caddyfile:/etc/caddy/Caddyfile caddy-failover:ordering-test caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+fi
+
+# Test 3: Using route instead of handle (should succeed)
+echo ""
+echo "Test 3: Using route instead of handle (expected to succeed)..."
+cat > test-with-route.Caddyfile <<EOF
+:8080 {
+    route /admin/failover/status {
+        failover_status
+    }
+}
+EOF
+
+echo "Testing configuration validation..."
+if docker run --rm -v $(pwd)/test-with-route.Caddyfile:/etc/caddy/Caddyfile caddy-failover:ordering-test caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile 2>&1 | grep -q "Valid configuration"; then
+    echo "✅ Test 3 PASSED: Configuration is valid with route directive"
+else
+    echo "❌ Test 3 FAILED: Configuration should be valid with route directive"
+    docker run --rm -v $(pwd)/test-with-route.Caddyfile:/etc/caddy/Caddyfile caddy-failover:ordering-test caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+fi
+
+# Test 4: Full working example
+echo ""
+echo "Test 4: Full working example with failover_status endpoint..."
+cat > test-full.Caddyfile <<EOF
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /api/* {
+        failover_proxy http://httpbin.org/anything https://httpbin.org/anything {
+            fail_duration 10s
+        }
+    }
+
+    handle {
+        respond "OK" 200
+    }
+}
+EOF
+
+echo "Starting test container..."
+docker run --rm -d \
+    --name caddy-ordering-test \
+    -v $(pwd)/test-full.Caddyfile:/etc/caddy/Caddyfile \
+    -p 8083:8080 \
+    caddy-failover:ordering-test
+
+echo "Waiting for container to start..."
+sleep 3
+
+echo "Testing status endpoint..."
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8083/admin/failover/status)
+if [ "$response" = "200" ]; then
+    echo "✅ Test 4 PASSED: Status endpoint returns 200"
+else
+    echo "❌ Test 4 FAILED: Status endpoint returned $response instead of 200"
+fi
+
+echo "Stopping test container..."
+docker stop caddy-ordering-test
+
+echo ""
+echo "Cleaning up test files..."
+rm -f test-*.Caddyfile
+
+echo ""
+echo "================================================"
+echo "Directive ordering tests completed!"


### PR DESCRIPTION
## Summary
- Improved documentation to clarify that `failover_status` directive requires proper ordering configuration
- Added comprehensive guide for resolving the "not an ordered HTTP handler" error
- Provided test script to verify directive ordering behavior

## Problem
Users encounter this error when using `failover_status` without proper ordering:
```
Error: adapting config using caddyfile: parsing caddyfile tokens for 'handle': 
directive 'failover_status' is not an ordered HTTP handler
```

## Solution
This PR documents two solutions:
1. **Add global order directive** (recommended):
   ```caddyfile
   {
       order failover_status before respond
   }
   ```
2. **Use route instead of handle** (no order needed)

## Changes
- Added `DIRECTIVE_ORDERING.md` with detailed explanation and examples
- Updated `README.md` to show both approaches for using `failover_status`
- Created `test-directive-ordering.sh` to verify the fix works correctly

## Test Plan
- [x] Run `./test-directive-ordering.sh` - all tests pass
- [x] Run `./test/test.sh` - integration tests pass
- [x] Validate Caddyfile configurations with and without ordering

🤖 Generated with [Claude Code](https://claude.ai/code)