### PR TITLE
fix: failover_status returning null when status_path not specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Monitor the health and status of all failover proxies via REST API:
     # Proxies with status tracking
     handle /auth/* {
         failover_proxy http://auth1.local http://auth2.local {
+            # status_path is recommended for clear path identification
+            # If not specified, an auto-generated identifier will be used
             status_path /auth/*
             health_check http://auth1.local {
                 path /health

--- a/example-config-with-status.Caddyfile
+++ b/example-config-with-status.Caddyfile
@@ -1,0 +1,360 @@
+# Caddy Configuration with Custom Failover Plugin - Fixed with status_path
+# Global admin API configuration
+{
+    admin :2019
+
+    # Order failover_proxy and failover_status
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+    # Optional: enable debug logging
+    debug
+}
+
+# HTTPS Server on port 9443
+https://localhost:9443 {
+    # Caddy will automatically generate self-signed certificates for localhost
+    # For production domains, Caddy will automatically obtain Let's Encrypt certificates
+
+    # Manual certificate loading (commented out for reference)
+    # tls /certs/aspnet.pem /certs/aspnet.key
+
+
+
+    # ===========================
+    # ADMIN API SERVICE (/admin/*)
+    # ===========================
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /admin/* {
+        failover_proxy http://host.docker.internal:5041 http://admin_api:80 https://dev.portal.the-commons.app {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+            insecure_skip_verify
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /admin/*
+
+            # Health checks for primary (local IDE)
+            health_check http://host.docker.internal:5041 {
+                path /health/ready
+                interval 10s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for docker container
+            health_check http://admin_api:80 {
+                path /health/ready
+                interval 10s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for fallback (remote)
+            health_check https://dev.portal.the-commons.app {
+                path /admin/health/ready
+                interval 60s
+                timeout 10s
+                expected_status 200
+            }
+
+            # Headers for HTTP upstream (IDE)
+            header_up http://host.docker.internal:5041 X-Service-Track caddy
+            header_up http://host.docker.internal:5041 X-Ingress caddy
+            header_up http://host.docker.internal:5041 Host dev.portal.the-commons.app
+
+            # Headers for HTTPS upstream (Remote)
+            header_up https://dev.portal.the-commons.app X-Service-Track caddy-fallback
+            header_up https://dev.portal.the-commons.app X-Ingress caddy
+            header_up https://dev.portal.the-commons.app Host dev.portal.the-commons.app
+        }
+    }
+
+    # ===========================
+    # GATEWAY SERVICE (/graphql*, /gateway/*)
+    # ===========================
+    handle /graphql* {
+        failover_proxy http://host.docker.internal:5021 https://dev.portal.the-commons.app {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+            insecure_skip_verify
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /graphql*
+
+            # Health checks for primary (local IDE)
+            health_check http://host.docker.internal:5021 {
+                path /gateway/health/ready
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for fallback (remote)
+            health_check https://dev.portal.the-commons.app {
+                path /gateway/health/ready
+                interval 60s
+                timeout 10s
+                expected_status 200
+            }
+
+            header_up http://host.docker.internal:5021 X-Service-Track caddy
+            header_up http://host.docker.internal:5021 X-Ingress caddy
+            header_up http://host.docker.internal:5021 Host dev.portal.the-commons.app
+
+            header_up https://dev.portal.the-commons.app X-Service-Track caddy-fallback
+            header_up https://dev.portal.the-commons.app X-Ingress caddy
+            header_up https://dev.portal.the-commons.app Host dev.portal.the-commons.app
+        }
+    }
+
+    handle /gateway/* {
+        failover_proxy http://host.docker.internal:5021 https://dev.portal.the-commons.app {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+            insecure_skip_verify
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /gateway/*
+
+            # Health checks for primary (local IDE)
+            health_check http://host.docker.internal:5021 {
+                path /gateway/health/ready
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for fallback (remote)
+            health_check https://dev.portal.the-commons.app {
+                path /gateway/health/ready
+                interval 60s
+                timeout 10s
+                expected_status 200
+            }
+
+            header_up http://host.docker.internal:5021 X-Service-Track caddy
+            header_up http://host.docker.internal:5021 X-Ingress caddy
+            header_up http://host.docker.internal:5021 Host dev.portal.the-commons.app
+
+            header_up https://dev.portal.the-commons.app X-Service-Track caddy-fallback
+            header_up https://dev.portal.the-commons.app X-Ingress caddy
+            header_up https://dev.portal.the-commons.app Host dev.portal.the-commons.app
+        }
+    }
+
+    # ===========================
+    # STUDENT API SERVICE (/student/*)
+    # ===========================
+    handle /student/* {
+        failover_proxy http://host.docker.internal:5061 https://dev.portal.the-commons.app {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+            insecure_skip_verify
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /student/*
+
+            # Health checks for primary (local IDE)
+            health_check http://host.docker.internal:5061 {
+                path /student/health/ready
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for fallback (remote)
+            health_check https://dev.portal.the-commons.app {
+                path /student/health/ready
+                interval 60s
+                timeout 10s
+                expected_status 200
+            }
+
+            header_up http://host.docker.internal:5061 X-Service-Track caddy
+            header_up http://host.docker.internal:5061 X-Ingress caddy
+            header_up http://host.docker.internal:5061 Host dev.portal.the-commons.app
+
+            header_up https://dev.portal.the-commons.app X-Service-Track caddy-fallback
+            header_up https://dev.portal.the-commons.app X-Ingress caddy
+            header_up https://dev.portal.the-commons.app Host dev.portal.the-commons.app
+        }
+    }
+
+    # ===========================
+    # STUDENT AUTH SERVICE (/auth/*)
+    # ===========================
+    handle /auth/* {
+        failover_proxy http://host.docker.internal:5051 https://dev.portal.the-commons.app {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+            insecure_skip_verify
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /auth/*
+
+            # Health checks for primary (local IDE)
+            health_check http://host.docker.internal:5051 {
+                path /auth/health/ready
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health checks for fallback (remote)
+            health_check https://dev.portal.the-commons.app {
+                path /auth/health/ready
+                interval 60s
+                timeout 10s
+                expected_status 200
+            }
+
+            header_up http://host.docker.internal:5051 X-Service-Track caddy
+            header_up http://host.docker.internal:5051 X-Ingress caddy
+            header_up http://host.docker.internal:5051 Host dev.portal.the-commons.app
+
+            header_up https://dev.portal.the-commons.app X-Service-Track caddy-fallback
+            header_up https://dev.portal.the-commons.app X-Ingress caddy
+            header_up https://dev.portal.the-commons.app Host dev.portal.the-commons.app
+        }
+    }
+
+    # ===========================
+    # CMS (DIRECTUS) SERVICE (/cms/*)
+    # ===========================
+    handle /cms/* {
+        failover_proxy http://directus:8055 {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /cms/*
+
+            # Health check for Directus
+            health_check http://directus:8055 {
+                path /server/health
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            header_up http://directus:8055 X-Service-Track caddy
+            header_up http://directus:8055 X-Ingress caddy
+        }
+    }
+
+    # ===========================
+    # WEB WORKER SERVICE (/web-worker/*)
+    # ===========================
+    handle /web-worker/* {
+        failover_proxy http://host.docker.internal:5045 http://web_worker:80 {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /web-worker/*
+
+            # Health check for primary (local IDE)
+            health_check http://host.docker.internal:5045 {
+                path /health
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Health check for fallback (Docker container)
+            health_check http://web_worker:80 {
+                path /health
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            # Headers for local IDE
+            header_up http://host.docker.internal:5045 X-Service-Track caddy
+            header_up http://host.docker.internal:5045 X-Ingress caddy
+            header_up http://host.docker.internal:5045 Host dev.portal.the-commons.app
+
+            # Headers for Docker container
+            header_up http://web_worker:80 X-Service-Track caddy-docker
+            header_up http://web_worker:80 X-Ingress caddy
+        }
+    }
+
+    # ===========================
+    # DASHBOARD (/dx/*)
+    # ===========================
+    handle /dx/* {
+        failover_proxy http://host.docker.internal:5174 {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /dx/*
+
+            # Health check for dashboard (Vite dev server)
+            health_check http://host.docker.internal:5174 {
+                path /dx
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+
+            header_up http://host.docker.internal:5174 X-Service-Track caddy
+            header_up http://host.docker.internal:5174 X-Ingress caddy
+        }
+    }
+
+    # ===========================
+    # CADDY ADMIN API (/caddy-admin/*)
+    # ===========================
+    handle /caddy-admin/* {
+        uri strip_prefix /caddy-admin
+        failover_proxy http://localhost:2019 {
+            fail_duration 3s
+            dial_timeout 2s
+            response_timeout 5s
+
+            # IMPORTANT: Add status_path for status tracking
+            status_path /caddy-admin/*
+
+            # Health check for Caddy Admin API
+            health_check http://localhost:2019 {
+                path /config/
+                interval 30s
+                timeout 5s
+                expected_status 200
+            }
+        }
+    }
+
+    # ===========================
+    # ROOT REDIRECT
+    # ===========================
+    handle / {
+        redir /dx permanent
+    }
+}
+
+# HTTP Server on port 9080 - redirect to HTTPS
+http://localhost:9080 {
+    # Health check endpoint
+    handle /health {
+        respond "OK" 200
+    }
+
+    # Redirect all other traffic to HTTPS
+    handle {
+        redir https://localhost:9443{uri} permanent
+    }
+}

--- a/test-status-tracking.sh
+++ b/test-status-tracking.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Test script for verifying status tracking with and without status_path
+
+set -e
+
+echo "Testing failover_status tracking behavior"
+echo "=========================================="
+
+# Build the Docker image
+echo "Building Docker image..."
+docker build -t caddy-failover:status-test .
+
+# Test 1: Without status_path (should auto-detect from handle path)
+echo ""
+echo "Test 1: Auto-detection of path from handle block..."
+cat > test-auto-path.Caddyfile <<EOF
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+    debug
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /admin/* {
+        failover_proxy http://httpbin.org/anything https://httpbin.org/anything {
+            fail_duration 10s
+            # Note: no status_path specified - should auto-detect from handle
+        }
+    }
+
+    handle /api/* {
+        failover_proxy http://httpbin.org/anything https://httpbin.org/anything {
+            fail_duration 10s
+            # Note: no status_path specified - should auto-detect from handle
+        }
+    }
+}
+EOF
+
+echo "Starting container with auto-path detection..."
+docker run --rm -d \
+    --name caddy-status-test \
+    -v $(pwd)/test-auto-path.Caddyfile:/etc/caddy/Caddyfile \
+    -p 8091:8080 \
+    caddy-failover:status-test
+
+echo "Waiting for container to start..."
+sleep 3
+
+echo "Checking status endpoint (auto-detected paths)..."
+response=$(curl -s http://localhost:8091/admin/failover/status)
+echo "Response: $response"
+
+if [ "$response" = "[]" ] || [ "$response" = "null" ]; then
+    echo "❌ Test 1 FAILED: No proxies registered (auto-detection failed)"
+    docker logs caddy-status-test 2>&1 | tail -20
+else
+    echo "$response" | python3 -m json.tool
+    echo "✅ Test 1 PASSED: Proxies registered with auto-detected paths"
+fi
+
+docker stop caddy-status-test
+
+# Test 2: With explicit status_path
+echo ""
+echo "Test 2: Explicit status_path configuration..."
+cat > test-explicit-path.Caddyfile <<EOF
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+    debug
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /admin/* {
+        failover_proxy http://httpbin.org/anything https://httpbin.org/anything {
+            fail_duration 10s
+            status_path /admin/*
+        }
+    }
+
+    handle /api/* {
+        failover_proxy http://httpbin.org/anything https://httpbin.org/anything {
+            fail_duration 10s
+            status_path /api/*
+        }
+    }
+}
+EOF
+
+echo "Starting container with explicit status_path..."
+docker run --rm -d \
+    --name caddy-status-test \
+    -v $(pwd)/test-explicit-path.Caddyfile:/etc/caddy/Caddyfile \
+    -p 8091:8080 \
+    caddy-failover:status-test
+
+echo "Waiting for container to start..."
+sleep 3
+
+echo "Checking status endpoint (explicit paths)..."
+response=$(curl -s http://localhost:8091/admin/failover/status)
+echo "Response: $response"
+
+if [ "$response" = "[]" ] || [ "$response" = "null" ]; then
+    echo "❌ Test 2 FAILED: No proxies registered even with explicit status_path"
+    docker logs caddy-status-test 2>&1 | tail -20
+else
+    echo "$response" | python3 -m json.tool
+    echo "✅ Test 2 PASSED: Proxies registered with explicit paths"
+fi
+
+docker stop caddy-status-test
+
+# Test 3: Test with health checks
+echo ""
+echo "Test 3: Status with health checks enabled..."
+cat > test-health.Caddyfile <<EOF
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+}
+
+:8080 {
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    handle /admin/* {
+        failover_proxy http://httpbin.org/anything http://localhost:9999 {
+            fail_duration 10s
+            status_path /admin/*
+
+            health_check http://httpbin.org/anything {
+                path /status/200
+                interval 5s
+                timeout 2s
+                expected_status 200
+            }
+
+            health_check http://localhost:9999 {
+                path /health
+                interval 5s
+                timeout 2s
+                expected_status 200
+            }
+        }
+    }
+}
+EOF
+
+echo "Starting container with health checks..."
+docker run --rm -d \
+    --name caddy-status-test \
+    -v $(pwd)/test-health.Caddyfile:/etc/caddy/Caddyfile \
+    -p 8091:8080 \
+    caddy-failover:status-test
+
+echo "Waiting for health checks to run..."
+sleep 8
+
+echo "Checking status endpoint with health check data..."
+response=$(curl -s http://localhost:8091/admin/failover/status)
+echo "$response" | python3 -m json.tool || echo "$response"
+
+docker stop caddy-status-test
+
+echo ""
+echo "Cleaning up test files..."
+rm -f test-*.Caddyfile
+
+echo ""
+echo "=========================================="
+echo "Status tracking tests completed!"

--- a/test/test-failover-logs.sh
+++ b/test/test-failover-logs.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Test script to verify failover warning logs and health check user agent
+
+set -e
+
+echo "Testing failover warning logs and health check user agent..."
+echo "=================================================="
+
+# Build the plugin
+echo "Building Caddy with failover plugin..."
+docker build -t caddy-failover:test .
+
+# Create a mock server that logs headers
+echo "Creating mock server with header logging..."
+cat > mock-server-with-headers.js <<'EOF'
+const http = require('http');
+
+const server = http.createServer((req, res) => {
+  // Log request with headers
+  console.log(`[${new Date().toISOString()}] ${req.method} ${req.url}`);
+  console.log(`User-Agent: ${req.headers['user-agent'] || 'not set'}`);
+
+  // Health check endpoint
+  if (req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('OK');
+    return;
+  }
+
+  // Normal response
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({
+    method: req.method,
+    url: req.url,
+    headers: req.headers,
+    timestamp: new Date().toISOString()
+  }));
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Mock server listening on port ${port}`);
+});
+EOF
+
+# Start mock server
+echo "Starting mock server..."
+docker run --rm -d \
+    --name mock-server-headers \
+    --network bridge \
+    -p 3002:3000 \
+    -v $(pwd)/mock-server-with-headers.js:/app/server.js \
+    node:20-alpine \
+    node /app/server.js
+
+# Get mock server IP
+MOCK_SERVER_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mock-server-headers)
+echo "Mock server IP: $MOCK_SERVER_IP"
+
+# Create Caddyfile with health checks and failover
+cat > test-failover-logs.Caddyfile <<EOF
+{
+    order failover_proxy before reverse_proxy
+    debug
+}
+
+:8080 {
+    handle /test {
+        # First upstream will always fail, forcing failover
+        failover_proxy http://localhost:9999 http://$MOCK_SERVER_IP:3000 {
+            fail_duration 5s
+            dial_timeout 1s
+            response_timeout 2s
+
+            # Health check for the mock server
+            health_check http://$MOCK_SERVER_IP:3000 {
+                path /health
+                interval 2s
+                timeout 1s
+                expected_status 200
+            }
+        }
+    }
+}
+EOF
+
+# Start Caddy
+echo "Starting Caddy..."
+docker run --rm -d \
+    --name caddy-failover-test \
+    --network bridge \
+    -v $(pwd)/test-failover-logs.Caddyfile:/etc/caddy/Caddyfile \
+    -p 8091:8080 \
+    caddy-failover:test
+
+echo "Waiting for services to start and health checks to run..."
+sleep 4
+
+echo ""
+echo "Test 1: Checking health check User-Agent..."
+echo "-------------------------------------------"
+docker logs mock-server-headers 2>&1 | grep "User-Agent:" | head -3
+echo ""
+echo "✅ Health check User-Agent should be: Caddy-failover-health-check/1.0"
+
+echo ""
+echo "Test 2: Testing failover warning log..."
+echo "----------------------------------------"
+echo "Making request that will trigger failover..."
+curl -s http://localhost:8091/test > /dev/null
+
+echo ""
+echo "Caddy logs showing failover warning:"
+docker logs caddy-failover-test 2>&1 | grep -E "(failing over|upstream failed)" | tail -5
+echo ""
+echo "✅ Should see 'failing over to alternate upstream' warning"
+
+echo ""
+echo "Test 3: Verify request succeeded despite first upstream failure..."
+echo "-------------------------------------------------------------------"
+response=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8091/test)
+if [ "$response" = "200" ]; then
+    echo "✅ Request succeeded with failover (HTTP $response)"
+else
+    echo "❌ Request failed (HTTP $response)"
+    docker logs caddy-failover-test
+fi
+
+echo ""
+echo "Cleaning up..."
+docker stop mock-server-headers caddy-failover-test 2>/dev/null || true
+rm -f test-failover-logs.Caddyfile mock-server-with-headers.js
+
+echo ""
+echo "=================================================="
+echo "✅ Failover logging tests completed!"


### PR DESCRIPTION
## Summary
- Fixed issue where `failover_status` endpoint returns `null` instead of JSON when `status_path` is not explicitly configured
- Auto-generates path identifiers when `status_path` is not provided to ensure all proxies register for status tracking
- **NEW**: Added warning log when failover occurs to an alternate upstream server
- **NEW**: Changed health check User-Agent to `Caddy-failover-health-check/1.0` for better observability
- Maintains backward compatibility with explicit `status_path` configuration

## Problem
The user reported that the `/admin/failover/status` endpoint was returning `null` instead of the expected JSON failover status. Investigation revealed that proxies were only registering with the global registry when `status_path` was explicitly configured in the Caddyfile.

## Solution
1. **Status Tracking Fix**: Modified the `Provision()` function in `failover.go` to auto-generate a path identifier using the format `auto:<first-upstream>` when `status_path` is not specified. This ensures all failover proxies register with the global registry and appear in status reports.

2. **Failover Warning Logs**: Added warning-level logging when the proxy fails over to an alternate upstream. The log includes:
   - Primary upstream that failed
   - Alternate upstream being used
   - Request method and path
   - Upstream index for debugging

3. **Health Check User-Agent**: Set custom User-Agent header `Caddy-failover-health-check/1.0` for all health check requests to make them easily identifiable in upstream server logs.

## Changes Made
- `failover.go`:
  - Lines 176-179: Auto-generate path identifier when not specified
  - Lines 415-416: Set custom User-Agent for health check requests
  - Lines 495-529: Track attempted upstreams and log failover warnings
- `test/test-failover-logs.sh`: New test script to verify failover logging and health check User-Agent
- Documentation updates in README and example configurations

## Test Plan
- [x] Created comprehensive test script (`test-status-tracking.sh`) to verify:
  - Auto-generated path identifiers work correctly
  - Explicit `status_path` configuration still works
  - Health check information is properly reported
- [x] Created new test script (`test-failover-logs.sh`) to verify:
  - Failover warning logs appear when switching to alternate upstream
  - Health check requests use custom User-Agent
  - Failover functionality continues to work correctly
- [x] Created example configuration file showing proper `status_path` usage
- [x] Updated README documentation to clarify `status_path` behavior
- [x] All existing tests pass

## Breaking Changes
None - all changes are fully backward compatible. Existing configurations will continue to work as before.

## Example Logs
```
WARN  failing over to alternate upstream  {"primary": "http://localhost:9999", "failover_to": "http://172.17.0.2:3000", "upstream_index": 1, "method": "GET", "path": "/test"}
```

Health check requests now appear in upstream logs as:
```
User-Agent: Caddy-failover-health-check/1.0
```

🤖 Generated with [Claude Code](https://claude.ai/code)