### PR TITLE
fix: enable Docker image builds on semantic releases

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -61,6 +61,8 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     needs: test-plugin
+    # Skip Docker builds on PRs - they'll run when merged to main
+    if: github.event_name != 'pull_request'
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
             @semantic-release/git \
             @semantic-release/github \
             @semantic-release/commit-analyzer \
-            @semantic-release/release-notes-generator
+            @semantic-release/release-notes-generator \
+            @semantic-release/exec
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,6 +11,12 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    "@semantic-release/github",
+    [
+      "@semantic-release/exec",
+      {
+        "successCmd": "echo \"new_release_published=true\" >> $GITHUB_OUTPUT && echo \"new_release_version=${nextRelease.version}\" >> $GITHUB_OUTPUT"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
- Add @semantic-release/exec plugin to set GitHub Actions outputs
- Configure exec plugin to output new_release_published and new_release_version
- These outputs are required for Docker build steps to execute properly
- Fixes issue where Docker images weren't being created for new releases

The workflow was previously skipping Docker builds because semantic-release wasn't setting the required output variables that the conditional steps depend on.