### PR TITLE
fix: update Docker documentation with semantic versioning examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,17 @@ xcaddy build --with github.com/ejlevin1/caddy-failover=.
 
 ### Using Docker
 
-Pull the pre-built image:
+Pull the pre-built image with semantic versioning tags:
 
 ```bash
+# Latest version
 docker pull ghcr.io/ejlevin1/caddy-failover:latest
+
+# Specific version
+docker pull ghcr.io/ejlevin1/caddy-failover:1.6.1
+
+# Major version (gets latest 1.x.x)
+docker pull ghcr.io/ejlevin1/caddy-failover:1
 ```
 
 Or build your own:


### PR DESCRIPTION
## Summary
This PR updates the Docker documentation to show the semantic versioning tags that will be available once Docker image builds are working.

## Purpose
- Documents the available Docker tag formats
- Provides a valid `fix:` commit to trigger semantic-release
- Will create v1.6.2 release which should build Docker images with the exec plugin now in place

## Changes
- Updated README.md with Docker tag examples (latest, x.y.z, x.y, x)

## Test Plan
- [ ] Merge this PR
- [ ] Verify semantic-release creates v1.6.2
- [ ] Verify Docker images are built and pushed to ghcr.io
- [ ] Check that all expected tags are created (1.6.2, 1.6, 1, latest)

This PR serves as a test to ensure the Docker build pipeline works correctly after the fixes from PR #12.