### PR TITLE
fix: redesign proxy registry to fix status endpoint issues

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,0 +1,368 @@
+# /fix-issue [problem description]
+
+Systematically analyze and fix issues in the codebase with comprehensive planning, impact analysis, and testing strategies.
+
+## Usage
+
+```sh
+/fix-issue [brief description of the problem]
+```
+
+## Issue Resolution Process
+
+### 1. Branch Setup and Preparation
+
+#### Step 1.1: Identify Working Branch
+Ask the user: "Which branch should I base this fix on? (e.g., main, develop, or a specific feature branch)"
+
+#### Step 1.2: Update Local Repository
+```sh
+# Fetch latest changes from remote
+git fetch origin [branch-name]
+
+# Checkout and update the base branch
+git checkout [branch-name]
+git pull origin [branch-name]
+
+# Create new fix branch
+git checkout -b fix/[descriptive-issue-name]
+```
+
+### 2. Problem Analysis Phase
+
+#### Step 2.1: Clarify the Problem
+Before proceeding, ensure complete understanding:
+- **What is the expected behavior?**
+- **What is the actual behavior?**
+- **When did this issue start occurring?**
+- **Are there specific conditions that trigger it?**
+- **Are there error messages or logs?**
+- **What has already been tried?**
+
+If any aspect is unclear, ask specific questions before continuing.
+
+#### Step 2.2: Deep Root Cause Analysis
+**REQUIRED:** Perform comprehensive analysis including:
+
+##### Search for Related Code
+```sh
+# Search for error messages
+grep -r "error message" --include="*.go" --include="*.js" --include="*.ts"
+
+# Search for related function names
+grep -r "function_name" --include="*.go"
+
+# Find all usages of the problematic component
+grep -r "ComponentName" --include="*.go"
+```
+
+##### Trace Execution Flow
+- Identify entry points
+- Map the call chain
+- Locate where the issue manifests
+- Find where the root cause originates
+
+##### Analyze Dependencies
+```sh
+# Check import statements
+grep -r "import.*problematic_package"
+
+# Review module dependencies
+cat go.mod | grep relevant_package
+
+# Check for recent changes
+git log -p --since="2 weeks ago" -- path/to/problematic/file
+```
+
+##### Review Related Tests
+```sh
+# Find existing tests
+find . -name "*_test.go" -exec grep -l "TestFunctionName" {} \;
+
+# Check test coverage
+go test -cover ./...
+```
+
+### 3. Solution Design Phase
+
+#### Step 3.1: Generate Multiple Approaches
+**REQUIRED:** Present 2-3 distinct high-level approaches:
+
+##### Approach Format:
+```markdown
+## Approach 1: [Descriptive Name]
+**Strategy:** [Brief description of the approach]
+**Pros:**
+- [Advantage 1]
+- [Advantage 2]
+**Cons:**
+- [Disadvantage 1]
+- [Disadvantage 2]
+**Estimated Complexity:** [Low/Medium/High]
+**Risk Assessment:** [Low/Medium/High]
+
+## Approach 2: [Descriptive Name]
+[Same structure as above]
+
+## Approach 3: [Descriptive Name]
+[Same structure as above]
+```
+
+#### Step 3.2: Get User Confirmation
+Present approaches and ask: "Which approach would you prefer, or would you like me to explore alternative solutions?"
+
+### 4. Detailed Implementation Planning
+
+#### Step 4.1: Comprehensive Code Analysis
+**REQUIRED:** After approach selection, perform deep analysis:
+
+##### Pattern Recognition
+```sh
+# Identify coding patterns in the codebase
+# Look for similar implementations
+find . -name "*.go" -exec grep -l "similar_pattern" {} \;
+
+# Review architectural patterns
+grep -r "interface.*Handler" --include="*.go"
+```
+
+##### Impact Analysis
+**REQUIRED:** Identify all affected areas:
+```sh
+# Find all files importing the module
+grep -r "import.*module_name" --include="*.go"
+
+# Find all references to the function/type
+grep -r "\bFunctionName\b" --include="*.go"
+
+# Check for interface implementations
+grep -r "type.*struct" --include="*.go" | xargs grep -l "InterfaceName"
+```
+
+##### Documentation Research
+**REQUIRED:** Use available resources:
+```markdown
+## Research Checklist:
+- [ ] Use context7 MCP to lookup latest library documentation
+- [ ] Search for similar issues in GitHub issues
+- [ ] Check Stack Overflow for related problems
+- [ ] Review library changelogs for breaking changes
+- [ ] Consult official documentation for best practices
+```
+
+Example context7 usage:
+- "Get documentation for [library-name] [specific-feature]"
+- "Search for [error-message] in [library-name] docs"
+
+#### Step 4.2: Identify Code Patterns to Follow
+```sh
+# Find established patterns for similar functionality
+grep -r "func.*Similar" --include="*.go" -A 10 -B 2
+
+# Review error handling patterns
+grep -r "if err != nil" --include="*.go" -A 3
+
+# Check logging patterns
+grep -r "log\." --include="*.go"
+
+# Review testing patterns
+find . -name "*_test.go" -exec head -50 {} \; | grep -A 10 "func Test"
+```
+
+### 5. Implementation Plan Presentation
+
+#### Step 5.1: Comprehensive Plan Document
+**REQUIRED:** Present the complete plan before implementation:
+
+```markdown
+# Implementation Plan for [Issue Description]
+
+## 1. Root Cause
+[Detailed explanation of why the issue occurs]
+
+## 2. Solution Overview
+[High-level description of the chosen approach]
+
+## 3. Code Changes
+
+### File: path/to/file1.go
+**Changes Required:**
+- Line XX-YY: [Description of change]
+- Line ZZ: [Description of change]
+**Reason:** [Why this change is necessary]
+
+### File: path/to/file2.go
+[Same structure as above]
+
+## 4. Potential Side Effects
+- **Area 1:** [Description of potential impact]
+  - Mitigation: [How to handle it]
+- **Area 2:** [Description of potential impact]
+  - Mitigation: [How to handle it]
+
+## 5. Testing Strategy
+
+### Unit Tests
+- [ ] Test case 1: [Description]
+- [ ] Test case 2: [Description]
+- [ ] Edge case: [Description]
+
+### Integration Tests
+- [ ] Scenario 1: [Description]
+- [ ] Scenario 2: [Description]
+
+### Manual Testing Steps
+1. [Step 1 description]
+2. [Step 2 description]
+3. [Expected result]
+
+## 6. Rollback Plan
+If issues arise after implementation:
+1. [Rollback step 1]
+2. [Rollback step 2]
+
+## 7. Documentation Updates
+- [ ] Update README if applicable
+- [ ] Update inline code comments
+- [ ] Update API documentation
+- [ ] Add changelog entry
+```
+
+#### Step 5.2: Get Final Approval
+Ask: "Does this implementation plan look good? Should I proceed with the fix, or would you like any modifications?"
+
+### 6. Implementation Phase
+
+#### Step 6.1: Implement Changes
+- Follow the approved plan exactly
+- Make incremental commits with clear messages
+- Add comprehensive comments for complex logic
+- Ensure code follows established patterns
+
+#### Step 6.2: Testing Implementation
+```sh
+# Run existing tests
+go test ./...
+
+# Run specific test file
+go test -v path/to/file_test.go
+
+# Run with race detection
+go test -race ./...
+
+# Run with coverage
+go test -cover ./...
+```
+
+#### Step 6.3: Write New Tests
+```go
+// Example test structure
+func TestFixedFunctionality(t *testing.T) {
+    // Arrange
+    [setup code]
+
+    // Act
+    [execute function]
+
+    // Assert
+    [verify results]
+}
+```
+
+### 7. Verification and Documentation
+
+#### Step 7.1: Final Verification Checklist
+- [ ] All tests pass
+- [ ] No linting errors
+- [ ] Code follows project conventions
+- [ ] Comments added where necessary
+- [ ] No debug code left behind
+- [ ] Performance impact assessed
+- [ ] Security implications reviewed
+
+#### Step 7.2: Create Pull Request
+```sh
+# Commit all changes
+git add -A
+git commit -m "fix: [concise description of fix]
+
+- [Bullet point 1 describing what was fixed]
+- [Bullet point 2 describing how it was fixed]
+- [Any additional relevant information]
+
+Fixes #[issue-number]"
+
+# Push branch
+git push -u origin fix/[descriptive-issue-name]
+
+# Create PR
+gh pr create --title "fix: [issue description]" \
+  --body "[Detailed PR description including problem, solution, and testing]"
+```
+
+## Required Analysis Tools
+
+### Code Search and Analysis
+- Use Grep tool for pattern matching
+- Use Glob tool for file discovery
+- Use Task tool for complex searches
+- Use Read tool for examining specific files
+
+### Documentation and Research
+- Use context7 MCP for library documentation
+- Use WebSearch for finding solutions
+- Use WebFetch for reading documentation pages
+- Check GitHub issues for similar problems
+
+### Testing and Validation
+- Run test suites
+- Perform manual testing
+- Verify edge cases
+- Check performance impact
+
+## Best Practices
+
+1. **Never skip the analysis phase** - Understanding the problem fully prevents incorrect fixes
+2. **Always present multiple approaches** - Different solutions have different trade-offs
+3. **Document everything** - Future developers need to understand why changes were made
+4. **Test comprehensively** - Automated and manual testing catch different issues
+5. **Follow existing patterns** - Consistency makes code maintainable
+6. **Consider side effects** - Every change can impact other parts of the system
+7. **Plan for rollback** - Always have a way to undo changes if needed
+
+## Common Pitfalls to Avoid
+
+- **Fixing symptoms instead of root causes** - Dig deeper to find the real issue
+- **Making assumptions without verification** - Always confirm your understanding
+- **Ignoring edge cases** - These often cause the most problems
+- **Skipping tests** - Tests prevent regressions
+- **Not considering performance** - Fixes shouldn't degrade performance
+- **Forgetting documentation** - Code without context is hard to maintain
+
+## Output Format
+
+The command should produce:
+1. Clear problem analysis
+2. Multiple solution approaches
+3. Detailed implementation plan
+4. Comprehensive test coverage
+5. Complete documentation
+6. Ready-to-merge pull request
+
+## Example Workflow
+
+```sh
+User: /fix-issue The API returns 500 errors when processing large files
+
+Claude: Which branch should I base this fix on? (e.g., main, develop, or a specific feature branch)
+
+User: main
+
+Claude: [Fetches latest from main, creates fix branch]
+        [Performs deep analysis of the issue]
+        [Presents 3 approaches with pros/cons]
+        [After user selects approach, performs impact analysis]
+        [Presents detailed implementation plan]
+        [After approval, implements fix with tests]
+        [Creates PR with comprehensive description]
+```

--- a/failover_test.go
+++ b/failover_test.go
@@ -1,0 +1,192 @@
+package caddyfailover
+
+import (
+	"testing"
+)
+
+func TestProxyRegistry(t *testing.T) {
+	// Create a new registry
+	registry := &ProxyRegistry{
+		proxies: make(map[string]*ProxyEntry),
+		order:   make([]string, 0),
+	}
+
+	// Create test proxies
+	proxy1 := &FailoverProxy{
+		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
+		HandlePath: "/auth/*",
+		Path:       "/auth/*",
+	}
+
+	proxy2 := &FailoverProxy{
+		Upstreams:  []string{"http://localhost:5041", "https://example.com"},
+		HandlePath: "/admin/*",
+		Path:       "/admin/*",
+	}
+
+	// Test duplicate registration with same path (should not duplicate)
+	proxy3 := &FailoverProxy{
+		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
+		HandlePath: "/auth/*",
+		Path:       "/auth/*",
+	}
+
+	// Register proxies
+	registry.Register("/auth/*", proxy1)
+	registry.Register("/admin/*", proxy2)
+	registry.Register("/auth/*", proxy3) // This should not create a duplicate
+
+	// Test that we have exactly 2 entries (no duplicates)
+	if len(registry.proxies) != 2 {
+		t.Errorf("Expected 2 entries in registry, got %d", len(registry.proxies))
+	}
+
+	// Test order preservation
+	if len(registry.order) != 2 {
+		t.Errorf("Expected 2 entries in order, got %d", len(registry.order))
+	}
+
+	if registry.order[0] != "/auth/*" || registry.order[1] != "/admin/*" {
+		t.Errorf("Order not preserved: %v", registry.order)
+	}
+
+	// Test GetStatus
+	status := registry.GetStatus()
+	if len(status) != 2 {
+		t.Errorf("Expected 2 status entries, got %d", len(status))
+	}
+
+	// Verify paths don't have "auto:" prefix
+	for _, s := range status {
+		if len(s.Path) > 5 && s.Path[:5] == "auto:" {
+			t.Errorf("Path should not have 'auto:' prefix, got: %s", s.Path)
+		}
+	}
+
+	// Test unregistration
+	registry.Unregister("/auth/*", proxy1)
+	if len(registry.proxies) != 1 {
+		t.Errorf("Expected 1 entry after unregister, got %d", len(registry.proxies))
+	}
+}
+
+func TestProxyRegistryNoDuplicateUpstreams(t *testing.T) {
+	registry := &ProxyRegistry{
+		proxies: make(map[string]*ProxyEntry),
+		order:   make([]string, 0),
+	}
+
+	// Create proxies with overlapping upstreams
+	proxy1 := &FailoverProxy{
+		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
+		HandlePath: "/api/*",
+		Path:       "/api/*",
+	}
+
+	proxy2 := &FailoverProxy{
+		Upstreams:  []string{"http://localhost:5051", "https://backup.com"},
+		HandlePath: "/api/*",
+		Path:       "/api/*",
+	}
+
+	// Register both proxies with same path
+	registry.Register("/api/*", proxy1)
+	registry.Register("/api/*", proxy2)
+
+	// Should have only one entry
+	if len(registry.proxies) != 1 {
+		t.Errorf("Expected 1 entry in registry, got %d", len(registry.proxies))
+	}
+
+	// Check that upstreams are tracked properly
+	entry := registry.proxies["/api/*"]
+	if entry == nil {
+		t.Fatal("Entry not found for /api/*")
+	}
+
+	// Should have 3 unique upstreams total
+	expectedUpstreams := map[string]bool{
+		"http://localhost:5051": true,
+		"https://example.com":   true,
+		"https://backup.com":    true,
+	}
+
+	if len(entry.Upstreams) != len(expectedUpstreams) {
+		t.Errorf("Expected %d unique upstreams, got %d", len(expectedUpstreams), len(entry.Upstreams))
+	}
+
+	for upstream := range expectedUpstreams {
+		if !entry.Upstreams[upstream] {
+			t.Errorf("Expected upstream %s to be tracked", upstream)
+		}
+	}
+}
+
+func TestProxyPathHandling(t *testing.T) {
+	tests := []struct {
+		name         string
+		proxy        *FailoverProxy
+		expectedPath string
+	}{
+		{
+			name: "Path and HandlePath both set",
+			proxy: &FailoverProxy{
+				Upstreams:  []string{"http://localhost:5051"},
+				HandlePath: "/auth/*",
+				Path:       "/auth/*",
+			},
+			expectedPath: "/auth/*",
+		},
+		{
+			name: "Only HandlePath set",
+			proxy: &FailoverProxy{
+				Upstreams:  []string{"http://localhost:5051"},
+				HandlePath: "/api/*",
+				Path:       "",
+			},
+			expectedPath: "/api/*",
+		},
+		{
+			name: "Only Path set",
+			proxy: &FailoverProxy{
+				Upstreams:  []string{"http://localhost:5051"},
+				HandlePath: "",
+				Path:       "/admin/*",
+			},
+			expectedPath: "/admin/*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := &ProxyRegistry{
+				proxies: make(map[string]*ProxyEntry),
+				order:   make([]string, 0),
+			}
+
+			// Determine registration path (mimics Provision logic)
+			registrationPath := tt.proxy.Path
+			if registrationPath == "" && tt.proxy.HandlePath != "" {
+				registrationPath = tt.proxy.HandlePath
+			}
+
+			if registrationPath != "" {
+				registry.Register(registrationPath, tt.proxy)
+			}
+
+			status := registry.GetStatus()
+			if len(status) != 1 {
+				t.Fatalf("Expected 1 status entry, got %d", len(status))
+			}
+
+			if status[0].Path != tt.expectedPath {
+				t.Errorf("Expected path %s, got %s", tt.expectedPath, status[0].Path)
+			}
+
+			// Ensure no "auto:" prefix
+			if len(status[0].Path) > 5 && status[0].Path[:5] == "auto:" {
+				t.Errorf("Path should not have 'auto:' prefix, got: %s", status[0].Path)
+			}
+		})
+	}
+}

--- a/test-status-fix.Caddyfile
+++ b/test-status-fix.Caddyfile
@@ -1,0 +1,35 @@
+{
+    order failover_proxy before reverse_proxy
+    order failover_status before respond
+    debug
+}
+
+:9090 {
+    # Status endpoint
+    handle /admin/failover/status {
+        failover_status
+    }
+
+    # Test path 1: Should show as /auth/* not auto:...
+    handle /auth/* {
+        failover_proxy http://localhost:5051 https://httpbin.org/anything {
+            fail_duration 3s
+            status_path /auth/*
+        }
+    }
+
+    # Test path 2: Should show as /admin/* not auto:...
+    handle /admin/* {
+        failover_proxy http://localhost:5041 http://localhost:5042 https://httpbin.org/anything {
+            fail_duration 3s
+            status_path /admin/*
+        }
+    }
+
+    # Test path 3: Without status_path, should use handle path
+    handle /api/* {
+        failover_proxy http://localhost:5021 https://httpbin.org/anything {
+            fail_duration 3s
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Redesigned the proxy registry to properly handle path tracking and prevent duplicates
- Fixed issue where paths showed as 'auto:http://host.docker.internal:5021' instead of clean paths like '/auth/*' or '/admin/*'
- Added deduplication logic and order preservation

## Problem
The failover status endpoint (/admin/failover/status) had several issues:
1. **Invalid path format**: Paths displayed as 'auto:http://host.docker.internal:5021' instead of the expected '/auth/*' or '/admin/*'
2. **Duplicate proxy entries**: Some failover proxies appeared multiple times in the status output
3. **Order not preserved**: The order of paths didn't match the Caddyfile configuration

## Solution
Implemented a complete registry redesign (Approach 3) with:
- New  structure to track unique proxies per path
- Ordered map to maintain registration order
- Deduplication logic at registration time
- Proper path handling using HandlePath or Path without auto-generation

## Changes
- Modified  structure to use ordered maps
- Updated registration logic to prevent duplicates
- Fixed path generation to use HandlePath/Path directly
- Added comprehensive unit tests

## Test Plan
✅ Unit tests added and passing:
-  - verifies no duplicates and order preservation
-  - ensures upstream deduplication
-  - validates proper path handling without 'auto:' prefix

✅ Manual testing:
- Created test Caddyfile configurations
- Verified status endpoint returns clean paths
- Confirmed no duplicate entries
- Validated order matches Caddyfile

## Breaking Changes
None - this is a bug fix that maintains backward compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)