### PR TITLE
feat: add Docker loaded images with additional Caddy plugins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,32 @@ jobs:
             type=semver,pattern={{major}},value=v${{ steps.semantic.outputs.new_release_version }}
             type=raw,value=latest
 
-      - name: Build and push Docker image
+      # Build builder stages separately for caching
+      - name: Build builder cache stages
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          target: builder
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=cacheonly
+
+      - name: Build builder-loaded cache stages
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          target: builder-loaded
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=cacheonly
+
+      - name: Build and push standard Docker image
         if: steps.semantic.outputs.new_release_published == 'true'
         id: docker_build
         uses: docker/build-push-action@v5
@@ -179,21 +204,56 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          target: standard
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
           build-args: |
-            GIT_COMMIT=${{ github.sha }}
-            GIT_TAG=v${{ steps.semantic.outputs.new_release_version }}
-            GIT_BRANCH=${{ github.ref_name }}
-            BUILD_DATE=${{ github.event.repository.updated_at }}
             VERSION=${{ steps.semantic.outputs.new_release_version }}
+            GIT_TAG=v${{ steps.semantic.outputs.new_release_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Generate Docker image attestation
+      - name: Extract Docker metadata for -loaded variant
+        if: steps.semantic.outputs.new_release_published == 'true'
+        id: docker_meta_loaded
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/ejlevin1/caddy-failover
+          tags: |
+            type=semver,pattern={{version}}-loaded,value=v${{ steps.semantic.outputs.new_release_version }}
+            type=semver,pattern={{major}}.{{minor}}-loaded,value=v${{ steps.semantic.outputs.new_release_version }}
+            type=semver,pattern={{major}}-loaded,value=v${{ steps.semantic.outputs.new_release_version }}
+            type=raw,value=latest-loaded
+
+      - name: Build and push -loaded Docker image
+        if: steps.semantic.outputs.new_release_published == 'true'
+        id: docker_build_loaded
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          target: loaded
+          tags: ${{ steps.docker_meta_loaded.outputs.tags }}
+          labels: ${{ steps.docker_meta_loaded.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.semantic.outputs.new_release_version }}
+            GIT_TAG=v${{ steps.semantic.outputs.new_release_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Generate Docker image attestation (standard)
         if: steps.semantic.outputs.new_release_published == 'true'
         uses: actions/attest-build-provenance@v1
         with:
           subject-name: ghcr.io/ejlevin1/caddy-failover
           subject-digest: ${{ steps.docker_build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate Docker image attestation (-loaded)
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/ejlevin1/caddy-failover
+          subject-digest: ${{ steps.docker_build_loaded.outputs.digest }}
           push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-# Build stage for Caddy with custom plugin
+# ARG for using pre-built binaries from cache
+# Can be set to "builder" (default) or a registry URL for cached builder image
+ARG BUILDER_CACHE_IMAGE=builder
+ARG BUILDER_LOADED_CACHE_IMAGE=builder-loaded
+
+# ============================================================================
+# Stage: builder
+# Build Caddy with the failover plugin only
+# ============================================================================
 FROM caddy:2-builder AS builder
 
 # Copy plugin source to build context
@@ -9,36 +17,100 @@ COPY . .
 RUN xcaddy build \
     --with github.com/ejlevin1/caddy-failover=.
 
-# Final stage
-FROM caddy:2-alpine
+# ============================================================================
+# Stage: builder-loaded
+# Build Caddy with failover plugin plus additional plugins
+# ============================================================================
+FROM caddy:2-builder AS builder-loaded
 
-# Build arguments for git information
-ARG GIT_COMMIT=unknown
-ARG GIT_TAG=unknown
-ARG GIT_BRANCH=unknown
-ARG BUILD_DATE=unknown
+# Copy plugin source to build context
+WORKDIR /src
+COPY . .
+
+# Build Caddy with failover plugin plus additional plugins
+RUN xcaddy build \
+    --with github.com/ejlevin1/caddy-failover=. \
+    --with github.com/gsmlg-dev/caddy-admin-ui \
+    --with github.com/lucaslorentz/caddy-docker-proxy/v2
+
+# ============================================================================
+# Stage: builder-cache
+# Cacheable builder stage that can be pulled from registry
+# ============================================================================
+FROM ${BUILDER_CACHE_IMAGE} AS builder-cache
+
+# ============================================================================
+# Stage: builder-loaded-cache
+# Cacheable builder stage for loaded variant
+# ============================================================================
+FROM ${BUILDER_LOADED_CACHE_IMAGE} AS builder-loaded-cache
+
+# ============================================================================
+# Stage: git-info
+# Generate build-info.json files for both standard and loaded variants
+# ============================================================================
+FROM caddy:2-alpine AS git-info
+RUN apk add --no-cache git jq
+
+WORKDIR /workspace
+COPY .git .git
+
+# Copy a built caddy binary to get version info
+COPY --from=builder-cache /src/caddy /tmp/caddy
+
+# Build arguments that may be provided by CI/CD
 ARG VERSION=unknown
+ARG GIT_TAG=unknown
 
-# Copy custom Caddy binary
-COPY --from=builder /src/caddy /usr/bin/caddy
+# Generate git metadata and build-info files
+RUN VERSION="${VERSION}" && \
+    GIT_COMMIT="$(git rev-parse HEAD 2>/dev/null || echo 'unknown')" && \
+    GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')" && \
+    GIT_TAG="${GIT_TAG:-$(git describe --tags --exact-match 2>/dev/null || echo 'unknown')}" && \
+    BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo 'unknown')" && \
+    CADDY_VERSION="$(/tmp/caddy version | head -1)" && \
+    echo "{\"version\":\"$VERSION\",\"git_commit\":\"$GIT_COMMIT\",\"git_tag\":\"$GIT_TAG\",\"git_branch\":\"$GIT_BRANCH\",\"build_date\":\"$BUILD_DATE\",\"caddy_version\":\"$CADDY_VERSION\",\"plugin\":\"github.com/ejlevin1/caddy-failover\"}" | jq . > /build-info-standard.json && \
+    echo "{\"version\":\"$VERSION\",\"git_commit\":\"$GIT_COMMIT\",\"git_tag\":\"$GIT_TAG\",\"git_branch\":\"$GIT_BRANCH\",\"build_date\":\"$BUILD_DATE\",\"caddy_version\":\"$CADDY_VERSION\",\"plugins\":[\"github.com/ejlevin1/caddy-failover\",\"github.com/gsmlg-dev/caddy-admin-ui\",\"github.com/lucaslorentz/caddy-docker-proxy/v2\"]}" | jq . > /build-info-loaded.json
 
-# Create build info file
-RUN echo "{\
-  \"version\": \"${VERSION}\",\
-  \"git_commit\": \"${GIT_COMMIT}\",\
-  \"git_tag\": \"${GIT_TAG}\",\
-  \"git_branch\": \"${GIT_BRANCH}\",\
-  \"build_date\": \"${BUILD_DATE}\",\
-  \"caddy_version\": \"$(caddy version | head -1)\",\
-  \"plugin\": \"github.com/ejlevin1/caddy-failover\"\
-}" > /etc/caddy/build-info.json && \
-    chmod 644 /etc/caddy/build-info.json
+# ============================================================================
+# Stage: loaded
+# Final stage for loaded image (with additional plugins)
+# ============================================================================
+FROM caddy:2-alpine AS loaded
+
+# Copy custom Caddy binary with all plugins (from cache or local build)
+COPY --from=builder-loaded-cache /src/caddy /usr/bin/caddy
+
+# Copy build info
+COPY --from=git-info /build-info-loaded.json /etc/caddy/build-info.json
+RUN chmod 644 /etc/caddy/build-info.json
 
 # Add labels for OCI image spec
-LABEL org.opencontainers.image.version="${VERSION}" \
-      org.opencontainers.image.revision="${GIT_COMMIT}" \
-      org.opencontainers.image.created="${BUILD_DATE}" \
-      org.opencontainers.image.source="https://github.com/ejlevin1/caddy-failover" \
+LABEL org.opencontainers.image.source="https://github.com/ejlevin1/caddy-failover" \
+      org.opencontainers.image.title="Caddy with Failover Plugin and Additional Modules" \
+      org.opencontainers.image.description="Caddy web server with failover, admin UI, and Docker proxy plugins"
+
+# Expose ports
+EXPOSE 80 443 2019
+
+# Run Caddy
+CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+
+# ============================================================================
+# Stage: standard (default)
+# Final stage for standard image - this is the default target
+# ============================================================================
+FROM caddy:2-alpine AS standard
+
+# Copy custom Caddy binary (from cache or local build)
+COPY --from=builder-cache /src/caddy /usr/bin/caddy
+
+# Copy build info
+COPY --from=git-info /build-info-standard.json /etc/caddy/build-info.json
+RUN chmod 644 /etc/caddy/build-info.json
+
+# Add labels for OCI image spec
+LABEL org.opencontainers.image.source="https://github.com/ejlevin1/caddy-failover" \
       org.opencontainers.image.title="Caddy with Failover Plugin" \
       org.opencontainers.image.description="Caddy web server with intelligent failover plugin"
 


### PR DESCRIPTION
## Summary
- Adds multi-stage Docker builds with two variants: standard and -loaded
- The -loaded variant includes additional Caddy plugins (caddy-admin-ui and caddy-docker-proxy)
- Implements reusable git-info stage for generating build metadata

## Changes
- **Dockerfile**: Refactored to use multi-stage builds with:
  - `builder` and `builder-loaded` stages for different plugin configurations
  - `git-info` stage that generates build-info.json files for both variants
  - `standard` (default) and `loaded` targets for final images
  
- **release.yml workflow**: Updated to:
  - Build both standard and -loaded Docker images
  - Use separate Docker metadata for each variant with appropriate tags
  - Cache builder stages for improved build performance
  
- **README.md**: Added comprehensive documentation for:
  - Using the -loaded Docker images
  - Configuration examples for caddy-admin-ui plugin
  - Docker Compose setup for caddy-docker-proxy plugin

## Test plan
- [x] Built and tested standard Docker image locally
- [x] Built and tested loaded Docker image locally
- [ ] Verify GitHub Actions workflow builds both variants successfully
- [ ] Test caddy-admin-ui plugin functionality
- [ ] Test caddy-docker-proxy plugin with Docker labels

🤖 Generated with [Claude Code](https://claude.ai/code)