### PR TITLE
fix: prevent codecov rate limits by optimizing upload strategy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Test Plugin
 
+# Coverage Upload Strategy:
+# - PRs: Optional coverage upload in test job (won't fail if rate limited)
+# - Main branch: Dedicated coverage-report job handles uploads
+# - Requires CODECOV_TOKEN secret to be set in repository settings
+# This prevents rate limit issues and duplicate uploads
+
 on:
   pull_request:
     branches:
@@ -53,12 +59,17 @@ jobs:
       - name: Run quick tests
         run: ./scripts/test.sh quick
 
-      - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.22'
-        uses: codecov/codecov-action@v3
+      # Optional coverage upload for PRs (won't fail if rate limited)
+      # Main branch coverage is handled by the dedicated coverage-report job
+      - name: Upload coverage to Codecov (PR only)
+        if: matrix.go-version == '1.22' && github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: false  # Don't fail PRs due to codecov issues
+          verbose: false
+          token: ${{ secrets.CODECOV_TOKEN }}  # v4 requires token
+        continue-on-error: true  # Continue even if upload fails
 
   benchmark:
     name: Run Benchmarks
@@ -124,6 +135,8 @@ jobs:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
     needs: test
+    # Only run on pushes to main branch to avoid rate limits
+    # This job handles all coverage uploads to Codecov
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     steps:
@@ -142,10 +155,12 @@ jobs:
         run: ./scripts/test.sh coverage -n
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.out
-          fail_ci_if_error: true
+          fail_ci_if_error: false  # Don't fail the workflow if codecov has issues
+          verbose: true  # Enable verbose output for debugging
+          token: ${{ secrets.CODECOV_TOKEN }}  # v4 requires token
 
   integration-test:
     name: Run Integration Tests


### PR DESCRIPTION
## Summary
- Fixes codecov rate limit issues that were causing CI failures on main branch merges
- Optimizes coverage upload strategy to prevent duplicate uploads
- Makes coverage uploads more resilient to temporary codecov issues

## Problem
The CI was failing on main branch merges due to codecov rate limits. The workflow was uploading coverage reports multiple times:
1. Once in the test job (for every push and PR)
2. Once in the coverage-report job (for main branch pushes)

This was causing duplicate uploads and hitting rate limits, as seen in: https://github.com/ejlevin1/caddy-failover/actions/runs/17016514020/job/48239898422

## Solution
- **Remove duplicate uploads**: Coverage for main branch is now only uploaded by the dedicated `coverage-report` job
- **PR coverage is optional**: PRs still get coverage reports but they won't fail if codecov has issues
- **Upgrade to codecov-action@v4**: Better rate limit handling but requires CODECOV_TOKEN
- **Error handling**: Added `continue-on-error` and `fail_ci_if_error: false` to prevent CI failures

## Changes
- Removed coverage upload from main test job for push events
- Added optional PR-only coverage upload that won't fail the build
- Upgraded codecov-action from v3 to v4 (requires CODECOV_TOKEN secret)
- Added proper error handling to prevent CI failures from codecov issues
- Added documentation explaining the coverage upload strategy

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test PR coverage upload doesn't fail if codecov has issues
- [ ] Verify main branch coverage still works with dedicated job
- [ ] Ensure CODECOV_TOKEN secret is configured in repository settings

🤖 Generated with [Claude Code](https://claude.ai/code)