### PR TITLE
fix: remove status_path directive and fix API registrar path duplication

### DIFF
--- a/.claude/commands/pre-commit-push.md
+++ b/.claude/commands/pre-commit-push.md
@@ -1,0 +1,161 @@
+# /pre-git-push [commit message]
+
+Comprehensive pre-push validation ensuring code quality, test coverage, and documentation before pushing changes.
+
+## Usage
+```sh
+/pre-git-push [optional commit message]
+```
+
+## Validation Process
+
+### 1. Repository State Check
+
+#### Step 1.1: Branch Protection Verification
+**Detect protected branches** (main, master, develop, staging, release/*, production):
+- Warn immediately if on protected branch
+- Offer to create feature branch
+- Require explicit confirmation to continue
+
+#### Step 1.2: Status Summary
+Show current branch, uncommitted changes, commits ahead, and protection status.
+
+### 2. Code Formatting
+
+#### Step 2.1: Format Changed Files Only
+**IMPORTANT:** Only format files that have been modified in this commit.
+```markdown
+## 🎨 Formatting Modified Files
+
+Detecting changed files...
+Found [X] modified files to format
+
+Applying formatters to YOUR changes only:
+- [List of your modified files being formatted]
+
+Files reformatted: [Count]
+No other files touched.
+```
+
+**Never format files outside the current changeset** - this prevents:
+- Unrelated formatting changes in PR
+- Merge conflicts from formatting other code
+- Accidental modification of working code
+- Scope creep in commits
+
+### 3. Test Execution
+
+#### Step 3.1: Run Test Suites
+Execute tests in order of importance:
+- **Unit Tests** - Component isolation
+- **Integration Tests** - Component interaction
+- **E2E Tests** - User workflows
+- **Performance Tests** - Response times and memory
+- **Contract Tests** - API compatibility
+
+#### Step 3.2: Results Summary
+Show passed/failed/skipped counts, coverage metrics, and performance baselines.
+
+### 4. Code Quality Checks
+
+#### Step 4.1: Static Analysis
+- Complexity analysis
+- Duplication detection
+- Dead code identification
+- Type safety validation
+
+#### Step 4.2: Security Scanning
+Check for secrets, vulnerabilities, injection risks, and dependency issues.
+
+### 5. Documentation Validation
+
+#### Step 5.1: Impact Analysis
+Identify what documentation needs updating based on changes:
+- New features requiring docs
+- API changes
+- Configuration updates
+- Breaking changes
+
+#### Step 5.2: Documentation Checklist
+- README.md current?
+- API docs complete?
+- CHANGELOG updated?
+- Code comments adequate?
+
+### 6. Build Verification
+
+Ensure production build succeeds and check for warnings.
+
+### 7. Custom Validations
+
+Offer optional additional checks:
+- Load testing
+- Accessibility audit
+- Database migration verification
+- Browser compatibility
+
+### 8. Final Review
+
+#### Step 8.1: Summary
+```markdown
+## Validation Complete
+
+✅ Passed: [List]
+⚠️ Warnings: [List]
+❌ Blockers: [List]
+
+Quality Metrics:
+- Coverage: XX%
+- Complexity: X.X
+- Build: Success
+
+Ready to push? [Yes/No]
+```
+
+### 9. Git Operations
+
+#### Step 9.1: Protected Branch Final Check
+If on protected branch, require typed confirmation:
+```
+⚠️ Type "CONFIRM PUSH TO [BRANCH]" or we'll create a feature branch instead:
+```
+
+#### Step 9.2: Commit and Push
+- Stage changes
+- Create descriptive commit
+- Push to remote
+- Offer PR creation
+
+## Best Practices
+
+1. **Only format changed files** - Don't touch unrelated code
+2. **Respect protected branches** - Use feature branches and PRs
+3. **Test before pushing** - Catch issues locally
+4. **Update docs immediately** - Harder to do later
+5. **Check security always** - Vulnerabilities compound
+6. **Monitor performance** - Prevent degradation
+
+## Example Workflow
+
+```sh
+User: /pre-git-push fix: auth timeout
+
+Claude: ⚠️ You're on 'main' branch (protected).
+        Create feature branch instead? (recommended)
+
+User: Yes
+
+Claude: Created 'fix/auth-timeout' branch
+
+        Formatting YOUR 3 changed files only...
+        ✅ Tests: 145/145 passed
+        ✅ Security: Clean
+        📚 Update CHANGELOG.md for this fix?
+
+User: Yes, updated
+
+Claude: All validations passed!
+        Pushing to origin/fix/auth-timeout...
+
+        Create PR to main? [Yes/No]
+```

--- a/example-config-with-status.Caddyfile
+++ b/example-config-with-status.Caddyfile
@@ -1,4 +1,4 @@
-# Caddy Configuration with Custom Failover Plugin - Fixed with status_path
+# Caddy Configuration with Custom Failover Plugin
 # Global admin API configuration
 {
     admin :2019
@@ -34,8 +34,6 @@ https://localhost:9443 {
             response_timeout 5s
             insecure_skip_verify
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /admin/*
 
             # Health checks for primary (local IDE)
             health_check http://host.docker.internal:5041 {
@@ -83,8 +81,6 @@ https://localhost:9443 {
             response_timeout 5s
             insecure_skip_verify
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /graphql*
 
             # Health checks for primary (local IDE)
             health_check http://host.docker.internal:5021 {
@@ -119,8 +115,6 @@ https://localhost:9443 {
             response_timeout 5s
             insecure_skip_verify
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /gateway/*
 
             # Health checks for primary (local IDE)
             health_check http://host.docker.internal:5021 {
@@ -158,8 +152,6 @@ https://localhost:9443 {
             response_timeout 5s
             insecure_skip_verify
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /student/*
 
             # Health checks for primary (local IDE)
             health_check http://host.docker.internal:5061 {
@@ -197,8 +189,6 @@ https://localhost:9443 {
             response_timeout 5s
             insecure_skip_verify
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /auth/*
 
             # Health checks for primary (local IDE)
             health_check http://host.docker.internal:5051 {
@@ -235,8 +225,6 @@ https://localhost:9443 {
             dial_timeout 2s
             response_timeout 5s
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /cms/*
 
             # Health check for Directus
             health_check http://directus:8055 {
@@ -260,8 +248,6 @@ https://localhost:9443 {
             dial_timeout 2s
             response_timeout 5s
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /web-worker/*
 
             # Health check for primary (local IDE)
             health_check http://host.docker.internal:5045 {
@@ -299,8 +285,6 @@ https://localhost:9443 {
             dial_timeout 2s
             response_timeout 5s
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /dx/*
 
             # Health check for dashboard (Vite dev server)
             health_check http://host.docker.internal:5174 {
@@ -325,8 +309,6 @@ https://localhost:9443 {
             dial_timeout 2s
             response_timeout 5s
 
-            # IMPORTANT: Add status_path for status tracking
-            status_path /caddy-admin/*
 
             # Health check for Caddy Admin API
             health_check http://localhost:2019 {

--- a/failover/failover_benchmark_test.go
+++ b/failover/failover_benchmark_test.go
@@ -87,7 +87,6 @@ func BenchmarkProxyRegistryRegister(b *testing.B) {
 				proxy := &FailoverProxy{
 					Upstreams:  []string{fmt.Sprintf("http://localhost:%d", 5000+i)},
 					HandlePath: path,
-					Path:       path,
 				}
 				registry.Register(path, proxy)
 			}
@@ -108,7 +107,6 @@ func BenchmarkProxyRegistryGetStatus(b *testing.B) {
 		proxy := &FailoverProxy{
 			Upstreams:  []string{fmt.Sprintf("http://localhost:%d", 5000+i)},
 			HandlePath: path,
-			Path:       path,
 		}
 		registry.Register(path, proxy)
 	}

--- a/failover/failover_test.go
+++ b/failover/failover_test.go
@@ -23,20 +23,17 @@ func TestProxyRegistry(t *testing.T) {
 	proxy1 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
 		HandlePath: "/auth/*",
-		Path:       "/auth/*",
 	}
 
 	proxy2 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5041", "https://example.com"},
 		HandlePath: "/admin/*",
-		Path:       "/admin/*",
 	}
 
 	// Test duplicate registration with same path (should not duplicate)
 	proxy3 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
 		HandlePath: "/auth/*",
-		Path:       "/auth/*",
 	}
 
 	// Register proxies
@@ -88,13 +85,11 @@ func TestProxyRegistryNoDuplicateUpstreams(t *testing.T) {
 	proxy1 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5051", "https://example.com"},
 		HandlePath: "/api/*",
-		Path:       "/api/*",
 	}
 
 	proxy2 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5051", "https://backup.com"},
 		HandlePath: "/api/*",
-		Path:       "/api/*",
 	}
 
 	// Register both proxies with same path
@@ -137,11 +132,10 @@ func TestProxyPathHandling(t *testing.T) {
 		expectedPath string
 	}{
 		{
-			name: "Path and HandlePath both set",
+			name: "HandlePath set",
 			proxy: &FailoverProxy{
 				Upstreams:  []string{"http://localhost:5051"},
 				HandlePath: "/auth/*",
-				Path:       "/auth/*",
 			},
 			expectedPath: "/auth/*",
 		},
@@ -150,7 +144,6 @@ func TestProxyPathHandling(t *testing.T) {
 			proxy: &FailoverProxy{
 				Upstreams:  []string{"http://localhost:5051"},
 				HandlePath: "/api/*",
-				Path:       "",
 			},
 			expectedPath: "/api/*",
 		},
@@ -158,8 +151,7 @@ func TestProxyPathHandling(t *testing.T) {
 			name: "Only Path set",
 			proxy: &FailoverProxy{
 				Upstreams:  []string{"http://localhost:5051"},
-				HandlePath: "",
-				Path:       "/admin/*",
+				HandlePath: "/admin/*",
 			},
 			expectedPath: "/admin/*",
 		},
@@ -173,10 +165,7 @@ func TestProxyPathHandling(t *testing.T) {
 			}
 
 			// Determine registration path (mimics Provision logic)
-			registrationPath := tt.proxy.Path
-			if registrationPath == "" && tt.proxy.HandlePath != "" {
-				registrationPath = tt.proxy.HandlePath
-			}
+			registrationPath := tt.proxy.HandlePath
 
 			if registrationPath != "" {
 				registry.Register(registrationPath, tt.proxy)
@@ -389,7 +378,6 @@ func TestFailoverStatusHandler(t *testing.T) {
 	proxy1 := &FailoverProxy{
 		Upstreams:  []string{"http://localhost:5051"},
 		HandlePath: "/api/*",
-		Path:       "/api/*",
 	}
 	registry.Register("/api/*", proxy1)
 

--- a/failover/test_helpers.go
+++ b/failover/test_helpers.go
@@ -139,7 +139,6 @@ func WithHealthCheck(upstream string, hc *HealthCheck) ProxyOption {
 // WithPath sets the path for the proxy
 func WithPath(path string) ProxyOption {
 	return func(fp *FailoverProxy) {
-		fp.Path = path
 		fp.HandlePath = path
 	}
 }
@@ -192,7 +191,6 @@ func CreateTestRegistry(paths ...string) *ProxyRegistry {
 		proxy := &FailoverProxy{
 			Upstreams:  []string{fmt.Sprintf("http://localhost:%d", 5000+i)},
 			HandlePath: path,
-			Path:       path,
 		}
 		registry.Register(path, proxy)
 	}

--- a/failover/test_helpers_test.go
+++ b/failover/test_helpers_test.go
@@ -279,10 +279,6 @@ func TestWithPath(t *testing.T) {
 	// Apply the option
 	WithPath(testPath)(proxy)
 
-	if proxy.Path != testPath {
-		t.Errorf("Expected Path %q, got %q", testPath, proxy.Path)
-	}
-
 	if proxy.HandlePath != testPath {
 		t.Errorf("Expected HandlePath %q, got %q", testPath, proxy.HandlePath)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -116,9 +116,8 @@ func TestFailoverStatusEndpointIntegration(t *testing.T) {
 				failover_status
 			}
 
-			handle {
+			handle /api {
 				failover_proxy %s %s {
-					status_path /api
 					fail_duration 1s
 					health_check %s {
 						path /health

--- a/test/test-failover-status.sh
+++ b/test/test-failover-status.sh
@@ -48,7 +48,6 @@ cat > test-status.Caddyfile << 'EOF'
     handle /auth/* {
         failover_proxy http://localhost:5051 https://httpbin.org/anything {
             fail_duration 3s
-            status_path /auth/*
 
             health_check http://localhost:5051 {
                 path /health
@@ -63,7 +62,6 @@ cat > test-status.Caddyfile << 'EOF'
     handle /admin/* {
         failover_proxy http://localhost:5041 http://localhost:5042 https://httpbin.org/anything {
             fail_duration 3s
-            status_path /admin/*
 
             health_check http://localhost:5041 {
                 path /health
@@ -74,7 +72,7 @@ cat > test-status.Caddyfile << 'EOF'
         }
     }
 
-    # Test path 3: /api/* (without explicit status_path)
+    # Test path 3: /api/*
     handle /api/* {
         failover_proxy http://localhost:5021 https://httpbin.org/anything {
             fail_duration 3s
@@ -92,7 +90,6 @@ cat > test-status.Caddyfile << 'EOF'
     handle /gateway/* {
         failover_proxy http://localhost:5021 https://httpbin.org/anything {
             fail_duration 3s
-            status_path /gateway/*
 
             health_check http://localhost:5021 {
                 path /gateway/health/ready

--- a/testdata/complex.Caddyfile
+++ b/testdata/complex.Caddyfile
@@ -10,7 +10,6 @@
     handle /auth/* {
         failover_proxy http://auth-primary.local:5051 http://auth-secondary.local:5052 {
             fail_duration 5s
-            status_path /auth/*
 
             health_check http://auth-primary.local:5051 {
                 path /health
@@ -35,7 +34,6 @@
     handle /admin/* {
         failover_proxy http://admin.local:5041 https://admin-backup.local:5042 {
             fail_duration 10s
-            status_path /admin/*
             insecure_skip_verify
 
             health_check http://admin.local:5041 {
@@ -67,7 +65,6 @@
     handle /gateway/* {
         failover_proxy http://gateway1.local:5021 http://gateway2.local:5022 http://gateway3.local:5023 {
             fail_duration 2s
-            status_path /gateway/*
 
             health_check http://gateway1.local:5021 {
                 path /gateway/health/ready


### PR DESCRIPTION
## Summary

- Fixed OpenAPI spec generation to use empty path since registration already provides the full path
- Removed redundant `status_path` directive - path is now automatically detected from the handle block
- Simplified internal path handling by removing the `Path` field and only using `HandlePath`

## Problem

1. The API registrar was creating duplicate paths in OpenAPI specs (e.g., `/caddy/failover/status/status`)
2. The `status_path` directive was redundant since the failover proxy already auto-detects its path from the handle block

## Solution

Both the API registrar and failover proxy now work consistently:
- They automatically detect their paths from the handle block context
- No manual path configuration is needed in most cases
- This prevents path duplication and configuration errors

## Changes

- Updated `failover/handler.go` to remove `status_path` directive and `Path` field
- Fixed OpenAPI spec generation to use empty endpoint path
- Updated all examples, tests, and documentation
- Removed `status_path` from all Caddyfiles

## Testing

All tests pass, including:
- Unit tests
- Integration tests  
- OpenAPI Docker tests

🤖 Generated with Claude Code