### PR TITLE
feat: add path directive support and enhanced error messages for snippets

### DIFF
--- a/api_registrar/registration_handler.go
+++ b/api_registrar/registration_handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"go.uber.org/zap"
 )
 
 func init() {
@@ -20,8 +21,12 @@ func init() {
 type ApiRegistrationHandler struct {
 	// APIs is a map of API ID to configuration
 	APIs map[string]*ApiRegistrationConfig `json:"apis,omitempty"`
-	// Path is the path where the APIs are registered (required)
+	// Path is the path where the APIs are registered (auto-detected or explicit)
 	Path string `json:"path,omitempty"`
+	// autoDetectedPath stores the auto-detected path for warning purposes (not serialized)
+	autoDetectedPath string
+	// logger for runtime warnings
+	logger *zap.Logger
 }
 
 // ApiRegistrationConfig contains configuration for a registered API
@@ -44,8 +49,18 @@ func (*ApiRegistrationHandler) CaddyModule() caddy.ModuleInfo {
 
 // Provision sets up the handler and registers the APIs
 func (h *ApiRegistrationHandler) Provision(ctx caddy.Context) error {
+	h.logger = ctx.Logger(h)
+
+	// Log warning if path was explicitly set when auto-detection was available
+	if h.autoDetectedPath != "" && h.Path != h.autoDetectedPath {
+		h.logger.Warn("path explicitly set, overriding auto-detected handle block path",
+			zap.String("explicit_path", h.Path),
+			zap.String("auto_detected_path", h.autoDetectedPath))
+	}
+
 	if h.Path == "" {
-		return fmt.Errorf("path is required for API registration")
+		// This shouldn't happen if parseApiRegistration works correctly, but be defensive
+		return fmt.Errorf("path could not be determined for API registration")
 	}
 
 	// Register each API with its path
@@ -90,7 +105,39 @@ func parseApiRegistration(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, 
 		APIs: make(map[string]*ApiRegistrationConfig),
 	}
 
+	// Try to extract the path from the current context
+	// This is important for API registration - the path will be auto-detected from the handle block
+	autoDetectedPath := ""
+	if h.State != nil {
+		// Debug: log what keys are available in State
+		// fmt.Printf("DEBUG: State keys: %v\n", h.State)
+
+		if segments := h.State["matcher_segments"]; segments != nil {
+			if segs, ok := segments.([]caddyhttp.MatcherSet); ok && len(segs) > 0 {
+				for _, matcherSet := range segs {
+					for _, matcher := range matcherSet {
+						if pathMatcher, ok := matcher.(caddyhttp.MatchPath); ok && len(pathMatcher) > 0 {
+							autoDetectedPath = string(pathMatcher[0])
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Check if we're in a snippet
+	snippetName := ""
+	if h.State != nil {
+		if name, ok := h.State["snippet_name"]; ok {
+			if nameStr, ok := name.(string); ok {
+				snippetName = nameStr
+			}
+		}
+	}
+
 	// Parse the directive
+	explicitPath := ""
 	for h.Next() {
 		// Should not have arguments in registration mode
 		if h.NextArg() {
@@ -101,11 +148,11 @@ func parseApiRegistration(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, 
 		for h.NextBlock(0) {
 			switch h.Val() {
 			case "path":
-				// Required path specification
+				// Optional path specification (overrides auto-detection)
 				if !h.NextArg() {
 					return nil, h.ArgErr()
 				}
-				handler.Path = h.Val()
+				explicitPath = h.Val()
 				if h.NextArg() {
 					return nil, h.ArgErr()
 				}
@@ -155,9 +202,47 @@ func parseApiRegistration(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, 
 		return nil, h.Err("caddy_api_registrar must have at least one API registered")
 	}
 
-	// Path is required for API registration
-	if handler.Path == "" {
-		return nil, h.Err("caddy_api_registrar requires a 'path' directive to specify where the API is mounted")
+	// Determine which path to use based on the fallback logic
+	// Get file and line information for better error reporting
+	file := h.File()
+	line := h.Line()
+
+	// Provide API-specific hints
+	hint := ""
+	for apiID := range handler.APIs {
+		switch apiID {
+		case "failover_api":
+			hint = " For failover_api, typically use 'path /caddy/failover/status'."
+		case "caddy_api":
+			hint = " For caddy_api, typically use 'path /caddy'."
+		}
+		break // Just use the first API's hint
+	}
+
+	// Apply fallback logic for path determination
+	if explicitPath != "" && autoDetectedPath != "" {
+		// Both explicit and auto-detected paths available - use explicit but warn
+		handler.Path = explicitPath
+		// Log warning will be done during Provision when we have access to logger
+		handler.autoDetectedPath = autoDetectedPath // Store for warning during provision
+	} else if explicitPath != "" {
+		// Only explicit path available - use it
+		handler.Path = explicitPath
+	} else if autoDetectedPath != "" {
+		// Only auto-detected path available - use it
+		handler.Path = autoDetectedPath
+	} else {
+		// No path available - error with helpful context
+		location := fmt.Sprintf("%s:%d", file, line)
+		if snippetName != "" {
+			location = fmt.Sprintf("%s:%d (in snippet '%s')", file, line, snippetName)
+			return nil, h.Errf("caddy_api_registrar at %s requires a 'path' directive. "+
+				"When used in snippets, path cannot be auto-detected from handle blocks. "+
+				"Add 'path /your/api/path' to fix this.%s", location, hint)
+		}
+		return nil, h.Errf("caddy_api_registrar at %s requires a 'path' directive. "+
+			"Either use it inside a 'handle /path/*' block or add 'path /your/api/path' explicitly.%s",
+			location, hint)
 	}
 
 	return handler, nil


### PR DESCRIPTION
## Summary
- Adds explicit `path` directive support to `failover_proxy` to resolve garbled path display issue
- Enhances `caddy_api_registrar` with auto-detection fallback and detailed error messages
- Improves developer experience with file/line number context in error messages

## Problem
When using Caddyfile snippets with handle blocks, the failover status endpoint would display garbled path values like `"auto-3831343530343837"` instead of actual paths. This occurred because the handle block context isn't available during snippet parsing, making path auto-detection impossible.

## Solution
Added support for an explicit `path` directive in both `failover_proxy` and `caddy_api_registrar` directives. When path auto-detection fails (such as in snippets), users can now specify paths manually to ensure correct display in the failover status endpoint.

## Changes
1. **failover/handler.go**:
   - Added parsing for optional `path` directive
   - Implemented fallback logic matching `caddy_api_registrar`
   - Enhanced error messages with file/line context

2. **api_registrar/registration_handler.go**:
   - Added auto-detection with fallback to explicit path
   - Improved error messages with API-specific hints
   - Added file/line number reporting for better debugging

## Test Results
✅ Built and tested locally with xcaddy
✅ Verified garbled path issue without explicit path directive
✅ Confirmed correct path display with explicit `path /api/*` directive
✅ Validated Caddyfile.failing configuration adapts without errors
✅ All pre-commit hooks and tests passing

## Example Usage
```caddyfile
(common_routes) {
    handle /api/* {
        failover_proxy http://backend1:80 http://backend2:80 {
            path /api/*  # Explicit path to avoid garbled display
            fail_duration 3s
        }
    }
}
```

## Breaking Changes
None - the `path` directive is optional and maintains backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)